### PR TITLE
Support ECDSA

### DIFF
--- a/RSAKeyVaultProvider.Tests/AzureFactAttribute.cs
+++ b/RSAKeyVaultProvider.Tests/AzureFactAttribute.cs
@@ -47,6 +47,8 @@ namespace RSAKeyVaultProviderTests
         public string TenantId { get; set; }
         public string AzureKeyVaultUrl { get; set; }
         public string AzureKeyVaultCertificateName { get; set; }
+        public string AzureKeyVaultECDsaCertificateName { get; set; }
         public string AzureKeyVaultKeyName { get; set; }
+        public string AzureKeyVaultECDsaKeyName { get; set; }
     }
 }

--- a/RSAKeyVaultProvider.Tests/ECDsaKeyVaultProviderTests.cs
+++ b/RSAKeyVaultProvider.Tests/ECDsaKeyVaultProviderTests.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Security.Cryptography;
+using Xunit;
+using RSAKeyVaultProvider;
+
+namespace RSAKeyVaultProviderTests
+{
+    public class ECDsaKeyVaultProviderTests
+    {
+        private readonly AzureKeyVaultSignConfigurationSet certificateConfiguration;
+        private readonly AzureKeyVaultSignConfigurationSet keyConfiguration;
+        private readonly AzureKeyVaultSignConfigurationSet certificateWithMSIConfiguration;
+
+        public ECDsaKeyVaultProviderTests()
+        {
+            var creds = TestAzureCredentials.Credentials;
+            if (creds is null)
+            {
+                return;
+            }
+            certificateConfiguration = new AzureKeyVaultSignConfigurationSet
+            {
+                AzureClientId = creds.ClientId,
+                AzureClientSecret = creds.ClientSecret,
+                AzureTenantId = creds.TenantId,
+                AzureKeyVaultUrl = new Uri(creds.AzureKeyVaultUrl),
+                AzureKeyVaultKeyName = creds.AzureKeyVaultECDsaCertificateName,
+
+                Mode = KeyVaultMode.Certificate
+            };
+
+            keyConfiguration = new AzureKeyVaultSignConfigurationSet
+            {
+                AzureClientId = creds.ClientId,
+                AzureClientSecret = creds.ClientSecret,
+                AzureTenantId = creds.TenantId,
+                AzureKeyVaultUrl = new Uri(creds.AzureKeyVaultUrl),
+                AzureKeyVaultKeyName = creds.AzureKeyVaultECDsaKeyName,
+                Mode = KeyVaultMode.Key
+            };
+
+            certificateWithMSIConfiguration = new AzureKeyVaultSignConfigurationSet
+            {
+                ManagedIdentity = true,
+                AzureKeyVaultUrl = new Uri(creds.AzureKeyVaultUrl),
+                AzureKeyVaultKeyName = creds.AzureKeyVaultECDsaCertificateName,
+                Mode = KeyVaultMode.Certificate
+            };
+        }
+
+        [AzureFact]
+        public async Task ShouldRoundTripASignatureWithCertificate()
+        {
+            var materialized = await KeyVaultConfigurationDiscoverer.Materialize(certificateConfiguration);
+
+            using (var ecdsa = materialized.ToECDsa())
+            using (var sha256 = SHA256.Create())
+            {
+                var data = new byte[] { 1, 2, 3 };
+                var digest = sha256.ComputeHash(data);
+                var signature = ecdsa.SignHash(digest);
+                var result = ecdsa.VerifyHash(digest, signature);
+                Assert.True(result);
+            }
+        }
+
+
+        [AzureFact]
+        public async Task ShouldRoundTripASignatureWithCertificateViaMsi()
+        {
+            var materialized = await KeyVaultConfigurationDiscoverer.Materialize(certificateWithMSIConfiguration);
+
+            using (var ecdsa = materialized.ToECDsa())
+            using (var sha256 = SHA256.Create())
+            {
+                var data = new byte[] { 1, 2, 3 };
+                var digest = sha256.ComputeHash(data);
+                var signature = ecdsa.SignHash(digest);
+                var result = ecdsa.VerifyHash(digest, signature);
+                Assert.True(result);
+            }
+        }
+
+        [AzureFact]
+        public async Task ShouldFailToVerifyBadSignatureWithCertificate()
+        {
+            var materialized = await KeyVaultConfigurationDiscoverer.Materialize(certificateConfiguration);
+            using (var ecdsa = materialized.ToECDsa())
+            using (var sha256 = SHA256.Create())
+            {
+                var data = new byte[] { 1, 2, 3 };
+                var digest = sha256.ComputeHash(data);
+                var signature = ecdsa.SignHash(digest);
+                signature[0] = (byte)~signature[0]; //Flip some bits.
+                var result = ecdsa.VerifyHash(digest, signature);
+                Assert.False(result);
+            }
+        }
+
+        [AzureFact]
+        public async Task ShouldHashDataAndVerifyWithCertificate()
+        {
+            var materialized = await KeyVaultConfigurationDiscoverer.Materialize(certificateConfiguration);
+            using (var ecdsa = materialized.ToECDsa())
+            {
+                var data = new byte[] { 1, 2, 3 };
+
+                var signature = ecdsa.SignData(data, HashAlgorithmName.SHA256);
+                var result = ecdsa.VerifyData(data, signature, HashAlgorithmName.SHA256);
+                Assert.True(result);
+            }
+        }
+
+        [AzureFact]
+        public async Task ShouldRoundTripASignatureWithKey()
+        {
+            var materialized = await KeyVaultConfigurationDiscoverer.Materialize(keyConfiguration);
+            using (var ecdsa = materialized.ToECDsa())
+            using (var sha256 = SHA256.Create())
+            {
+                var data = new byte[] { 1, 2, 3 };
+                var digest = sha256.ComputeHash(data);
+                var signature = ecdsa.SignHash(digest);
+                var result = ecdsa.VerifyHash(digest, signature);
+                Assert.True(result);
+            }
+        }
+
+        [AzureFact]
+        public async Task ShouldFailToVerifyBadSignatureWithKey()
+        {
+            var materialized = await KeyVaultConfigurationDiscoverer.Materialize(keyConfiguration);
+            using (var ecdsa = materialized.ToECDsa())
+            using (var sha256 = SHA256.Create())
+            {
+                var data = new byte[] { 1, 2, 3 };
+                var digest = sha256.ComputeHash(data);
+                var signature = ecdsa.SignHash(digest);
+                signature[0] = (byte)~signature[0]; //Flip some bits.
+                var result = ecdsa.VerifyHash(digest, signature);
+                Assert.False(result);
+            }
+        }
+
+        [AzureFact]
+        public async Task ShouldHashDataAndVerifyWithKey()
+        {
+            var materialized = await KeyVaultConfigurationDiscoverer.Materialize(keyConfiguration);
+            using (var ecdsa = materialized.ToECDsa())
+            {
+                var data = new byte[] { 1, 2, 3 };
+
+                var signature = ecdsa.SignData(data, HashAlgorithmName.SHA256);
+                var result = ecdsa.VerifyData(data, signature, HashAlgorithmName.SHA256);
+                Assert.True(result);
+            }
+        }
+
+        [AzureFact]
+        public async Task SignDataShouldThrowForUnsupportedHashAlgorithm()
+        {
+            var materialized = await KeyVaultConfigurationDiscoverer.Materialize(certificateConfiguration);
+            using (var ecdsa = materialized.ToECDsa())
+            {
+                var exception = Assert.Throws<NotSupportedException>(() =>
+                    ecdsa.SignData(Array.Empty<byte>(), new HashAlgorithmName("unsupported")));
+
+                Assert.Equal("The specified algorithm is not supported.", exception.Message);
+            }
+        }
+
+        [AzureFact]
+        public async Task VerifyDataShouldThrowForUnsupportedHashAlgorithm()
+        {
+            var materialized = await KeyVaultConfigurationDiscoverer.Materialize(certificateConfiguration);
+            using (var ecdsa = materialized.ToECDsa())
+            {
+                var exception = Assert.Throws<NotSupportedException>(() =>
+                    ecdsa.VerifyData(Array.Empty<byte>(), Array.Empty<byte>(),
+                        new HashAlgorithmName("unsupported")));
+
+                Assert.Equal("The specified algorithm is not supported.", exception.Message);
+            }
+        }
+
+        [Fact]
+        public void DefaultContextShouldThrow()
+        {
+            Assert.Throws<ArgumentException>(() => new ECDsaKeyVault(default(KeyVaultContext)));
+        }
+    }
+}

--- a/RSAKeyVaultProvider.Tests/ECDsaKeyVaultProviderTests.cs
+++ b/RSAKeyVaultProvider.Tests/ECDsaKeyVaultProviderTests.cs
@@ -171,6 +171,36 @@ namespace RSAKeyVaultProviderTests
         }
 
         [AzureFact]
+        public async Task SignHashShouldThrowForDigestAndKeySizeMismatch()
+        {
+            var materialized = await KeyVaultConfigurationDiscoverer.Materialize(keyConfiguration);
+            using (var ecdsa = materialized.ToECDsa())
+            using (var sha384 = SHA384.Create())
+            {
+                Assert.Equal(256, ecdsa.KeySize);
+
+                var data = new byte[] { 1, 2, 3 };
+                var digest = sha384.ComputeHash(data);
+                var ex = Assert.Throws<NotSupportedException>(() => ecdsa.SignHash(digest));
+                Assert.Equal("The key size '256' is not valid for digest of size '48' bytes.", ex.Message);
+            }
+        }
+
+        [AzureFact]
+        public async Task SignDataShouldThrowForDigestAndKeySizeMismatch()
+        {
+            var materialized = await KeyVaultConfigurationDiscoverer.Materialize(keyConfiguration);
+            using (var ecdsa = materialized.ToECDsa())
+            {
+                Assert.Equal(256, ecdsa.KeySize);
+
+                var data = new byte[] { 1, 2, 3 };
+                var ex = Assert.Throws<NotSupportedException>(() => ecdsa.SignData(data, HashAlgorithmName.SHA384));
+                Assert.Equal("The key size '256' is not valid for digest algorithm 'SHA384'.", ex.Message);
+            }
+        }
+
+        [AzureFact]
         public async Task VerifyDataShouldThrowForUnsupportedHashAlgorithm()
         {
             var materialized = await KeyVaultConfigurationDiscoverer.Materialize(certificateConfiguration);

--- a/RSAKeyVaultProvider.Tests/KeyVaultConfigurationDiscoverer.cs
+++ b/RSAKeyVaultProvider.Tests/KeyVaultConfigurationDiscoverer.cs
@@ -70,7 +70,6 @@ namespace RSAKeyVaultProviderTests
         /// Only contains the public key
         /// </summary>
         public JsonWebKey Key { get; }
-       
 
         public RSAKeyVault ToRSA()
         {
@@ -80,6 +79,16 @@ namespace RSAKeyVaultProviderTests
             }
 
             return (RSAKeyVault)RSAFactory.Create(TokenCredential, KeyIdentifier, Key);
+        }
+
+        public ECDsaKeyVault ToECDsa()
+        {
+            if (PublicCertificate != null)
+            {
+                return (ECDsaKeyVault)ECDsaFactory.Create(TokenCredential, KeyIdentifier, PublicCertificate);
+            }
+
+            return (ECDsaKeyVault)ECDsaFactory.Create(TokenCredential, KeyIdentifier, Key);
         }
     }
 }

--- a/RSAKeyVaultProvider.Tests/RSAKeyVaultProvider.Tests.csproj
+++ b/RSAKeyVaultProvider.Tests/RSAKeyVaultProvider.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net47;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>RSAKeyVaultProviderTests</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/RSAKeyVaultProvider/ECDsaKeyVault.cs
+++ b/RSAKeyVaultProvider/ECDsaKeyVault.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Security.Cryptography;
+
+namespace RSAKeyVaultProvider
+{
+    /// <summary>
+    /// ECDsa implementation that uses Azure Key Vault
+    /// </summary>
+    public sealed class ECDsaKeyVault : ECDsa
+    {
+        readonly KeyVaultContext context;
+        ECDsa publicKey;
+
+        /// <summary>
+        /// Creates a new ECDsaKeyVault instance
+        /// </summary>
+        /// <param name="context">Context with parameters</param>
+        public ECDsaKeyVault(KeyVaultContext context)
+        {
+            if (!context.IsValid)
+                throw new ArgumentException("Must not be the default", nameof(context));
+
+            this.context = context;
+            publicKey = context.Key.ToECDsa();
+            KeySizeValue = publicKey.KeySize;
+            LegalKeySizesValue = new[] { new KeySizes(publicKey.KeySize, publicKey.KeySize, 0) };
+        }
+
+        void CheckDisposed()
+        {
+            if (publicKey is null)
+                throw new ObjectDisposedException($"{nameof(ECDsaKeyVault)} is disposed.");
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                publicKey?.Dispose();
+                publicKey = null;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override byte[] SignHash(byte[] hash)
+        {
+            CheckDisposed();
+
+            if (hash.Length == 256 / 8 && KeySize == 256)
+                return context.SignDigest(hash, HashAlgorithmName.SHA256, KeyVaultSignatureAlgorithm.ECDsa);
+            if (hash.Length == 384 / 8 && KeySize == 384)
+                return context.SignDigest(hash, HashAlgorithmName.SHA384, KeyVaultSignatureAlgorithm.ECDsa);
+            if (hash.Length == 512 / 8 && KeySize == 521) //ES512 uses nistP521
+                return context.SignDigest(hash, HashAlgorithmName.SHA512, KeyVaultSignatureAlgorithm.ECDsa);
+
+            throw new ArgumentException("Digest length is not valid for the key size.", nameof(hash));
+        }
+
+        protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
+        {
+            IncrementalHash hash;
+
+            try
+            {
+                hash = IncrementalHash.CreateHash(hashAlgorithm);
+            }
+            catch
+            {
+                throw new NotSupportedException("The specified algorithm is not supported.");
+            }
+
+            using (hash)
+            {
+                hash.AppendData(data, offset, count);
+                return hash.GetHashAndReset();
+            }
+        }
+
+        /// <inheritdoc/>
+        public override bool VerifyHash(byte[] hash, byte[] signature)
+        {
+            CheckDisposed();
+
+            return publicKey.VerifyHash(hash, signature);
+        }
+
+        ///<inheritdoc/>
+        public override ECParameters ExportParameters(bool includePrivateParameters)
+        {
+            if (includePrivateParameters)
+                throw new CryptographicException("Private keys cannot be exported by this provider");
+
+            return publicKey.ExportParameters(false);
+        }
+
+        ///<inheritdoc/>
+        public override ECParameters ExportExplicitParameters(bool includePrivateParameters)
+        {
+            if (includePrivateParameters)
+                throw new CryptographicException("Private keys cannot be exported by this provider");
+
+            return publicKey.ExportExplicitParameters(false);
+        }
+
+        /// <summary>
+        /// Importing parameters is not supported.
+        /// </summary>
+        public override void ImportParameters(ECParameters parameters) =>
+            throw new NotSupportedException();
+
+        /// <summary>
+        /// Key generation is not supported.
+        /// </summary>
+        public override void GenerateKey(ECCurve curve) =>
+            throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        public override string ToXmlString(bool includePrivateParameters)
+        {
+            if (includePrivateParameters)
+                throw new CryptographicException("Private keys cannot be exported by this provider");
+
+            return publicKey.ToXmlString(false);
+        }
+
+        /// <summary>
+        /// Importing parameters from XML is not supported.
+        public override void FromXmlString(string xmlString) =>
+            throw new NotSupportedException();
+    }
+}

--- a/RSAKeyVaultProvider/ECDsaKeyVaultExtensions.cs
+++ b/RSAKeyVaultProvider/ECDsaKeyVaultExtensions.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+using Azure.Core;
+using Azure.Security.KeyVault.Keys;
+
+namespace RSAKeyVaultProvider
+{
+    /// <summary>
+    /// Extensions for creating ECDsa from a Key Vault client.
+    /// </summary>
+    public static class ECDsaFactory
+    {
+        /// <summary>
+        /// Creates an ECDsa object
+        /// </summary>
+        /// <param name="credential"></param>
+        /// <param name="keyId"></param>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public static ECDsa Create(TokenCredential credential, Uri keyId, JsonWebKey key)
+        {
+            if (credential is null)
+                throw new ArgumentNullException(nameof(credential));
+
+            if (keyId is null)
+                throw new ArgumentNullException(nameof(keyId));
+
+            if (key is null)
+                throw new ArgumentNullException(nameof(key));
+
+            return new ECDsaKeyVault(new KeyVaultContext(credential, keyId, key));
+        }
+
+        /// <summary>
+        /// Creates an ECDsa object
+        /// </summary>
+        /// <param name="credential"></param>
+        /// <param name="keyId"></param>
+        /// <param name="publicCertificate"></param>
+        /// <returns></returns>
+        public static ECDsa Create(TokenCredential credential, Uri keyId, X509Certificate2 publicCertificate)
+        {
+            if (credential is null)
+                throw new ArgumentNullException(nameof(credential));
+
+            if (keyId is null)
+                throw new ArgumentNullException(nameof(keyId));
+
+            if (publicCertificate is null)
+                throw new ArgumentNullException(nameof(publicCertificate));
+
+            return new ECDsaKeyVault(new KeyVaultContext(credential, keyId, publicCertificate));
+        }
+    }
+}

--- a/RSAKeyVaultProvider/RSAKeyVault.cs
+++ b/RSAKeyVaultProvider/RSAKeyVault.cs
@@ -38,7 +38,7 @@ namespace RSAKeyVaultProvider
 
             try
             {
-                return context.SignDigest(hash, hashAlgorithm);
+                return context.SignDigest(hash, hashAlgorithm, KeyVaultSignatureAlgorithm.RSAPkcs15);
             }
             catch (Exception e)
             {

--- a/RSAKeyVaultProvider/SignatureAlgorithm.cs
+++ b/RSAKeyVaultProvider/SignatureAlgorithm.cs
@@ -1,0 +1,8 @@
+namespace RSAKeyVaultProvider
+{
+    internal enum KeyVaultSignatureAlgorithm
+    {
+        RSAPkcs15,
+        ECDsa
+    }
+}

--- a/RSAKeyVaultProvider/SignatureAlgorithmTranslator.cs
+++ b/RSAKeyVaultProvider/SignatureAlgorithmTranslator.cs
@@ -7,19 +7,33 @@ namespace RSAKeyVaultProvider
 {
     static class SignatureAlgorithmTranslator
     {
-        public static SignatureAlgorithm SignatureAlgorithmToJwsAlgId(HashAlgorithmName hashAlgorithmName)
+        public static SignatureAlgorithm SignatureAlgorithmToJwsAlgId(KeyVaultSignatureAlgorithm signatureAlgorithm, HashAlgorithmName hashAlgorithmName)
         {
-            if (hashAlgorithmName == HashAlgorithmName.SHA1)
-                return new SignatureAlgorithm("RSNULL");
+            if (signatureAlgorithm == KeyVaultSignatureAlgorithm.RSAPkcs15)
+            {
+                if (hashAlgorithmName == HashAlgorithmName.SHA1)
+                    return new SignatureAlgorithm("RSNULL");
 
-            if (hashAlgorithmName == HashAlgorithmName.SHA256)
-                return SignatureAlgorithm.RS256;
+                if (hashAlgorithmName == HashAlgorithmName.SHA256)
+                    return SignatureAlgorithm.RS256;
 
-            if (hashAlgorithmName == HashAlgorithmName.SHA384)
-                return SignatureAlgorithm.RS384;
+                if (hashAlgorithmName == HashAlgorithmName.SHA384)
+                    return SignatureAlgorithm.RS384;
 
-            if (hashAlgorithmName == HashAlgorithmName.SHA512)
-                return SignatureAlgorithm.RS512;
+                if (hashAlgorithmName == HashAlgorithmName.SHA512)
+                    return SignatureAlgorithm.RS512;
+            }
+            else if (signatureAlgorithm == KeyVaultSignatureAlgorithm.ECDsa)
+            {
+                if (hashAlgorithmName == HashAlgorithmName.SHA256)
+                    return SignatureAlgorithm.ES256;
+                
+                if (hashAlgorithmName == HashAlgorithmName.SHA384)
+                    return SignatureAlgorithm.ES384;
+                
+                if (hashAlgorithmName == HashAlgorithmName.SHA512)
+                    return SignatureAlgorithm.ES512;
+            }
             
             throw new NotSupportedException("The algorithm specified is not supported.");
         }


### PR DESCRIPTION
Well, this perhaps might surprise people given the package/project name, but this is feasible for AKV to support now.

A couple of notes:

1. This will not work in net462 or below. The `ECParameters` struct is something that netstandard2.0 unfortunately lies about. Even though netstandard2.0 says ECParameters exists (and thus should be in net461) it does not. This type is used the the key vault library, so there isn't much we can do about it, I think. You'll just get a type load error at runtime.

2. I was not able to run the MSI tests; I'm not set up to run those.

3. Tests will probably fail until you generate an ECDsa certificate and update the azure-creds.json file.

    Steps to generate a self-signed ECDSA cert (requires recent version of OpenSSL):

    ```shell
    # Generate a private key
    openssl genpkey -algorithm ec -pkeyopt ec_paramgen_curve:prime256v1 -out ecdsa.key

    # Generate a self-signed certificate
    openssl req -x509 -key ecdsa.key -keyform pem -days 1095 -subj "/O=CI/CN=Self Signed Test Key" -out cert.pem

    # Combine in to PFX
    openssl pkcs12 -export -out cert.pfx -inkey ecdsa.key -in cert.pem
    ```